### PR TITLE
Add sphere generator

### DIFF
--- a/Lithophane_Example.ipynb
+++ b/Lithophane_Example.ipynb
@@ -19,6 +19,7 @@
    "source": [
     "# Lithophane Example \n",
     "written by Dirk Colbry\n",
+    "The sphere generator by Kunihiko Miyoshi\n",
     "\n",
     "Simple Example without all of the explaination. For a more detailed description see [Lithophane Tutorial](Lithophane_Tutorial.ipynb)"
    ]
@@ -29,7 +30,8 @@
    "metadata": {
     "colab": {},
     "colab_type": "code",
-    "id": "suEz-fCAL0wP"
+    "id": "suEz-fCAL0wP",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -82,7 +84,8 @@
     "colab_type": "code",
     "id": "CDrw-HPPuoQh",
     "outputId": "e3096c1c-6e63-40c4-c404-05142a967a80",
-    "scrolled": true
+    "scrolled": true,
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -140,7 +143,8 @@
     },
     "colab_type": "code",
     "id": "BHu6kTp_31Gk",
-    "outputId": "7e55e6ac-d1e3-48b6-b7b5-dd7086416d1f"
+    "outputId": "7e55e6ac-d1e3-48b6-b7b5-dd7086416d1f",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -162,6 +166,31 @@
     "#Save the Cylinder Model\n",
     "model = li.makemesh(cx,cy,cz);\n",
     "filename=imagefile[:-4] + '_Cylinder.stl'\n",
+    "model.save(filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Trun the flat pointcloud into a sphere\n",
+    "sfront, sback = li.makeSphere(x,y,z)\n",
+    "li.showstl(*sfront)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Save the Sphere Model\n",
+    "model = li.makeMeshSphere(sfront, sback)\n",
+    "filename=imagefile[:-4] + '_Sphere.stl'\n",
     "model.save(filename)"
    ]
   },
@@ -207,7 +236,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.3-final"
   }
  },
  "nbformat": 4,

--- a/lithophane.py
+++ b/lithophane.py
@@ -179,9 +179,9 @@ def makemesh(x, y, z):
     return model
 
 
-def makeSphere(x, y, z, radius=None, bottom_radian=0.85):
+def makeSphere(x, y, z, radius = 50, bottom_hole_radius = 10, thickness=2):
     '''Convert flat point cloud to Sphere'''
-    r_max = int(x.shape[0] * (1 - np.arccos(bottom_hole_radius / radius) / np.pi))
+    r_max = int(x.shape[0] * (1 - np.arcsin(bottom_hole_radius / radius) / np.pi))
     copy_target = slice(r_max)
     front_x = x[copy_target].copy()
     front_y = y[copy_target].copy()


### PR DESCRIPTION
Thank you for sharing the great work for the Python based lithophane model generator.
I added a sphere generator for this library.

[An example of sphere generation](https://colab.research.google.com/drive/1yem-eAWfhEUhQo7TSs5P52NpVFmE6FMJ) is also available.

The sphere lithophane fit together well with spherical images taken by 360 degree cameras.
The following example was generated by [a spherical image taken by Ricoh Theta](https://commons.wikimedia.org/wiki/File:TTA_HK_Central_Lai_Yuen_Amusement_Park_27-June-2015.JPG).

![image](https://user-images.githubusercontent.com/29963/94338726-80d77980-002f-11eb-8546-4a7814b9fcc3.png)

I had to add `makeMeshSphere` because the inner-back of the model must be also sphere.
I chose camelCase rule for this method though the original `makemesh` was not.
So I would ask this rule and I'll follow discussions and suggestions.